### PR TITLE
Implement customer-friendly errors in frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 1.0.2 (2017-09-02)
 ### Added
  - Backend menu option to display customer-friendly messages per store view.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+ - Backend menu option to display customer-friendly messages per store view.
+
 ## 1.0.1 (2017-02-12)
 ### Added
  - LICENSE file.

--- a/modman
+++ b/modman
@@ -1,2 +1,4 @@
 src/app/code/community/Defacto/*     app/code/community/Defacto/
 src/app/etc/modules/*    app/etc/modules/
+src/app/locale/de_DE/*    app/locale/de_DE/
+src/app/locale/en_US/*    app/locale/en_US/

--- a/src/app/code/community/Defacto/FixFormKeyException/Helper/Data.php
+++ b/src/app/code/community/Defacto/FixFormKeyException/Helper/Data.php
@@ -13,5 +13,15 @@
 class Defacto_FixFormKeyException_Helper_Data
     extends Mage_Core_Helper_Abstract
 {
+    const XML_PATH_FORM_KEY_MESSAGE = 'checkout/cart/defacto_form_key_message';
 
+    /**
+     * Returns the error message that is displayed to the customer on invalid form keys.
+     *
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return Mage::getStoreConfig(self::XML_PATH_FORM_KEY_MESSAGE);
+    }
 }

--- a/src/app/code/community/Defacto/FixFormKeyException/Model/Observer.php
+++ b/src/app/code/community/Defacto/FixFormKeyException/Model/Observer.php
@@ -53,12 +53,14 @@ class Defacto_FixFormKeyException_Model_Observer
             Mage_Core_Controller_Varien_Action::FLAG_NO_DISPATCH,
             true
         );
+
+        $helper = Mage::helper('defacto_fixformkeyexception');
         // set response to json error message
         $result = Mage::helper('core')
             ->jsonEncode(
                 array(
                     'success' => 0,
-                    'error'   => Mage::helper('checkout')->__('Invalid form key'),
+                    'error'   => $helper->__($helper->getErrorMessage()),
                 )
             );
         Mage::app()

--- a/src/app/code/community/Defacto/FixFormKeyException/etc/config.xml
+++ b/src/app/code/community/Defacto/FixFormKeyException/etc/config.xml
@@ -5,6 +5,24 @@
             <version>1.0.1</version>
         </Defacto_FixFormKeyException>
     </modules>
+    <default>
+        <checkout>
+            <cart>
+                <defacto_form_key_message>Please reload the page and try again.</defacto_form_key_message>
+            </cart>
+        </checkout>
+    </default>
+    <frontend>
+        <translate>
+            <modules>
+                <Defacto_FixFormKeyException>
+                    <files>
+                        <default>Defacto_FixFormKeyException.csv</default>
+                    </files>
+                </Defacto_FixFormKeyException>
+            </modules>
+        </translate>
+    </frontend>
     <global>
         <helpers>
             <defacto_fixformkeyexception>

--- a/src/app/code/community/Defacto/FixFormKeyException/etc/system.xml
+++ b/src/app/code/community/Defacto/FixFormKeyException/etc/system.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <sections>
+        <checkout>
+            <groups>
+                <cart>
+                    <fields>
+                        <defacto_form_key_message translate="label">
+                            <label>Error message when form key is invalid</label>
+                            <sort_order>50</sort_order>
+                            <frontend_type>text</frontend_type>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </defacto_form_key_message>
+                    </fields>
+                </cart>
+            </groups>
+        </checkout>
+    </sections>
+</config>

--- a/src/app/locale/de_DE/Defacto_FixFormKeyException.csv
+++ b/src/app/locale/de_DE/Defacto_FixFormKeyException.csv
@@ -1,0 +1,1 @@
+"Please reload the page and try again.","Bitte laden Sie die Seite neu und versuchen Sie es erneut."

--- a/src/app/locale/en_US/Defacto_FixFormKeyException.csv
+++ b/src/app/locale/en_US/Defacto_FixFormKeyException.csv
@@ -1,0 +1,1 @@
+"Please reload the page and try again.","Please reload the page and try again."


### PR DESCRIPTION
As customers don't know what to do with the message "Invalid form key" I implemented a backend option to specify customer-friendly messages for the frontend.

If you like it please feel free to merge.